### PR TITLE
fix: user nav urls

### DIFF
--- a/src/components/layouts/dashboard-layout/user-nav.tsx
+++ b/src/components/layouts/dashboard-layout/user-nav.tsx
@@ -73,7 +73,7 @@ export const UserNav = () => {
           <DropdownMenuGroup>
             {nav_items.map((item) => (
               <DropdownMenuItem key={item.title + item.href} asChild>
-                <NextLink href={`dashboard${item.href}`} className='flex justify-between'>
+                <NextLink href={`/dashboard/${item.href}`} className='flex justify-between'>
                   <span className='grow'>{t(item.title)}</span>
                   <DropdownMenuShortcut>{item.shortcut}</DropdownMenuShortcut>
                 </NextLink>


### PR DESCRIPTION
the prev version has bug if u navigate to any item of the list it navigate with new dashboard text at the url, for example if you navigate to accout you will go to:
/ar/dashboard/dashboard/account